### PR TITLE
Allow configurable decimation and larger images in apriltags_cuda

### DIFF
--- a/src/apriltag_gpu.h
+++ b/src/apriltag_gpu.h
@@ -217,12 +217,12 @@ private:
           .cols = width_,
           .step = width_,
       };
-    } else if (memory.size() == width_ * height_ / 4) {
+    } else if (memory.size() == decimated_width_ * decimated_height_) {
       return GpuImage<T>{
           .data = memory.get(),
-          .rows = height_ / 2,
-          .cols = width_ / 2,
-          .step = width_ / 2,
+          .rows = decimated_height_,
+          .cols = decimated_width_,
+          .step = decimated_width_,
       };
     } else {
       LOG(FATAL) << "Unknown image shape";
@@ -232,6 +232,9 @@ private:
   // Size of the image.
   const size_t width_;
   const size_t height_;
+  const size_t decimation_;
+  const size_t decimated_width_;
+  const size_t decimated_height_;
 
   // Detector parameters.
   apriltag_detector_t *tag_detector_;
@@ -271,7 +274,7 @@ private:
   GpuMemory<uint8_t> color_image_device_;
   // Full size gray scale image.
   GpuMemory<uint8_t> gray_image_device_;
-  // Half resolution, gray, decimated image.
+  // Decimated gray image.
   GpuMemory<uint8_t> decimated_image_device_;
   // Intermediates for thresholding.
   GpuMemory<uint8_t> unfiltered_minmax_image_device_;

--- a/src/points.cu
+++ b/src/points.cu
@@ -9,7 +9,7 @@ std::ostream &operator<<(std::ostream &os, const QuadBoundaryPoint &point) {
   std::ios_base::fmtflags original_flags = os.flags();
 
   os << "key:" << std::hex << std::setw(16) << std::setfill('0') << point.key
-     << " rep01:" << std::setw(10) << point.rep01() << " pt:" << std::setw(6)
+     << " rep01:" << std::setw(10) << point.rep01() << " pt:" << std::setw(10)
      << point.point_bits();
   os.flags(original_flags);
   return os;
@@ -22,12 +22,12 @@ std::ostream &operator<<(std::ostream &os, const IndexPoint &point) {
   std::ios_base::fmtflags original_flags = os.flags();
 
   os << "key:" << std::hex << std::setw(16) << std::setfill('0') << point.key
-     << " i:" << std::setw(3) << point.blob_index() << " t:" << std::setw(7)
-     << point.theta() << " p:" << std::setw(6) << point.point_bits();
+     << " i:" << std::setw(3) << point.blob_index() << " t:" << std::setw(8)
+     << point.theta() << " p:" << std::setw(10) << point.point_bits();
   os.flags(original_flags);
   return os;
 }
 
 static_assert(sizeof(IndexPoint) == 8, "IndexPoint didn't pack right.");
 
-}  // namespace frc971::apriltag
+} // namespace frc971::apriltag

--- a/src/points.h
+++ b/src/points.h
@@ -16,61 +16,61 @@ namespace frc971::apriltag {
 // Class to hold the 2 adjacent blob IDs, a point in decimated image space, the
 // half pixel offset, and the gradient.
 //
-// rep0 and rep1 are the two blob ids, and are each allocated 20 bits.
-// point is the base point and is allocated 10 bits for x and 10 bits for y.
+// rep0 and rep1 are the two blob ids, and are each allocated 15 bits.
+// point is the base point and is allocated 13 bits for x and 13 bits for y.
 // dx and dy are allocated 2 bits, and can only take on set values.
 // black_to_white captures the direction of the gradient in 1 bit.
 //
 // This adds up to 63 bits so we can load this with one big load.
 struct QuadBoundaryPoint {
-  static constexpr size_t kRepEndBit = 24;
+  static constexpr size_t kRepEndBit = 30;
   static constexpr size_t kBitsInKey = 64;
 
   __forceinline__ __host__ __device__ QuadBoundaryPoint() : key(0) {}
 
-  // Sets rep0, the 0th blob id.  This only respects the bottom 20 bits.
+  // Sets rep0, the 0th blob id.  This only respects the bottom 15 bits.
   __forceinline__ __host__ __device__ void set_rep0(uint32_t rep0) {
-    key = (key & 0xfffff00000ffffffull) |
-          (static_cast<uint64_t>(rep0 & 0xfffff) << 24);
+    key = (key & ~(((uint64_t)0x7fff) << 30)) |
+          (static_cast<uint64_t>(rep0 & 0x7fff) << 30);
   }
   // Returns rep0.
   __forceinline__ __host__ __device__ uint32_t rep0() const {
-    return ((key >> 24) & 0xfffff);
+    return ((key >> 30) & 0x7fff);
   }
 
-  // Sets rep1, the 1st blob id.  This only respects the bottom 20 bits.
+  // Sets rep1, the 1st blob id.  This only respects the bottom 15 bits.
   __forceinline__ __host__ __device__ void set_rep1(uint32_t rep1) {
-    key = (key & 0xfffffffffffull) |
-          (static_cast<uint64_t>(rep1 & 0xfffff) << 44);
+    key = (key & ~(((uint64_t)0x7fff) << 45)) |
+          (static_cast<uint64_t>(rep1 & 0x7fff) << 45);
   }
   // Returns rep1.
   __forceinline__ __host__ __device__ uint32_t rep1() const {
-    return ((key >> 44) & 0xfffff);
+    return ((key >> 45) & 0x7fff);
   }
 
-  // Returns both rep0 and rep1 concatenated into a single 40 bit number.
+  // Returns both rep0 and rep1 concatenated into a single 30 bit number.
   __forceinline__ __host__ __device__ uint64_t rep01() const {
-    return ((key >> 24) & 0xffffffffff);
+    return ((key >> 30) & 0x3fffffff);
   }
 
   // Returns all the bits used to hold position and gradient information.
   __forceinline__ __host__ __device__ uint32_t point_bits() const {
-    return key & 0xffffff;
+    return key & 0x3fffffff;
   }
 
-  // Sets the 10 bit x and y.
+  // Sets the 13 bit x and y.
   __forceinline__ __host__ __device__ void set_base_xy(uint32_t x, uint32_t y) {
-    key = (key & 0xffffffffff00000full) |
-          (static_cast<uint64_t>(x & 0x3ff) << 14) |
-          (static_cast<uint64_t>(y & 0x3ff) << 4);
+    key = (key & ~((((uint64_t)0x1fff) << 17) | (((uint64_t)0x1fff) << 4))) |
+          (static_cast<uint64_t>(x & 0x1fff) << 17) |
+          (static_cast<uint64_t>(y & 0x1fff) << 4);
   }
 
-  // Returns the base 10 bit x and y.
+  // Returns the base 13 bit x and y.
   __forceinline__ __host__ __device__ uint32_t base_x() const {
-    return ((key >> 14) & 0x3ff);
+    return ((key >> 17) & 0x1fff);
   }
   __forceinline__ __host__ __device__ uint32_t base_y() const {
-    return ((key >> 4) & 0x3ff);
+    return ((key >> 4) & 0x1fff);
   }
 
   // Sets dxy, the integer representing which of the 4 search directions we
@@ -165,12 +165,12 @@ std::ostream &operator<<(std::ostream &os, const QuadBoundaryPoint &point);
 // Holds a compacted blob index, the angle to the X axis from the center of the
 // blob, and the coordinate of the point.
 //
-// The blob index is 12 bits, the angle is 28 bits, and the point is 24 bits.
+// The blob index is 11 bits, the angle is 23 bits, and the point is 30 bits.
 struct IndexPoint {
   // Max number of blob IDs we can hold.
   static constexpr size_t kMaxBlobs = 2048;
 
-  static constexpr size_t kRepEndBit = 24;
+  static constexpr size_t kRepEndBit = 30;
   static constexpr size_t kBitsInKey = 64;
 
   __forceinline__ __host__ __device__ IndexPoint() : key(0) {}
@@ -180,41 +180,41 @@ struct IndexPoint {
   // by hand.
   __forceinline__ __host__ __device__ IndexPoint(uint32_t blob_index,
                                                  uint32_t point_bits)
-      : key((static_cast<uint64_t>(blob_index & 0xfff) << 52) |
-            (static_cast<uint64_t>(point_bits & 0xffffff))) {}
+      : key((static_cast<uint64_t>(blob_index & 0x7ff) << 53) |
+            (static_cast<uint64_t>(point_bits & 0x3fffffff))) {}
 
-  // Sets and gets the 12 bit blob index.
+  // Sets and gets the 11 bit blob index.
   __forceinline__ __host__ __device__ void set_blob_index(uint32_t blob_index) {
-    key = (key & 0x000fffffffffffffull) |
-          (static_cast<uint64_t>(blob_index & 0xfff) << 52);
+    key = (key & ~(((uint64_t)0x7ff) << 53)) |
+          (static_cast<uint64_t>(blob_index & 0x7ff) << 53);
   }
   __forceinline__ __host__ __device__ uint32_t blob_index() const {
-    return ((key >> 52) & 0xfff);
+    return ((key >> 53) & 0x7ff);
   }
 
-  // Sets and gets the 28 bit angle.
+  // Sets and gets the 23 bit angle.
   __forceinline__ __host__ __device__ void set_theta(uint32_t theta) {
-    key = (key & 0xfff0000000ffffffull) |
-          (static_cast<uint64_t>(theta & 0xfffffff) << 24);
+    key = (key & ~(((uint64_t)0x7fffff) << 30)) |
+          (static_cast<uint64_t>(theta & 0x7fffff) << 30);
   }
   __forceinline__ __host__ __device__ uint32_t theta() const {
-    return ((key >> 24) & 0xfffffff);
+    return ((key >> 30) & 0x7fffff);
   }
 
   // See QuadBoundaryPoint for a description of the rest of these.
-  // Sets the 10 bit x and y.
+  // Sets the 13 bit x and y.
   __forceinline__ __host__ __device__ void set_base_xy(uint32_t x, uint32_t y) {
-    key = (key & 0xffffffffff00000full) |
-          (static_cast<uint64_t>(x & 0x3ff) << 14) |
-          (static_cast<uint64_t>(y & 0x3ff) << 4);
+    key = (key & ~((((uint64_t)0x1fff) << 17) | (((uint64_t)0x1fff) << 4))) |
+          (static_cast<uint64_t>(x & 0x1fff) << 17) |
+          (static_cast<uint64_t>(y & 0x1fff) << 4);
   }
 
   __forceinline__ __host__ __device__ uint32_t base_x() const {
-    return ((key >> 14) & 0x3ff);
+    return ((key >> 17) & 0x1fff);
   }
 
   __forceinline__ __host__ __device__ uint32_t base_y() const {
-    return ((key >> 4) & 0x3ff);
+    return ((key >> 4) & 0x1fff);
   }
 
   __forceinline__ __host__ __device__ void set_dxy(uint64_t dxy) {
@@ -262,7 +262,7 @@ struct IndexPoint {
   }
 
   __forceinline__ __host__ __device__ uint32_t point_bits() const {
-    return key & 0xffffff;
+    return key & 0x3fffffff;
   }
 
   __forceinline__ __host__ __device__ void

--- a/src/threshold.h
+++ b/src/threshold.h
@@ -12,7 +12,7 @@ namespace frc971::apriltag {
 void CudaToGreyscaleAndDecimateHalide(
     const uint8_t *color_image, uint8_t *gray_image, uint8_t *decimated_image,
     uint8_t *unfiltered_minmax_image, uint8_t *minmax_image,
-    uint8_t *thresholded_image, size_t width, size_t height,
+    uint8_t *thresholded_image, size_t width, size_t height, size_t decimation,
     size_t min_white_black_diff, CudaStream *stream);
 
 } // namespace frc971::apriltag


### PR DESCRIPTION
## Summary
- support up to 5120×5120 images by widening point coordinate storage and relaxing pixel count checks
- parameterize decimation factor across GPU detector and thresholding pipeline
- shrink angle scaling to fit within new packed point representation

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6891787671c0832191bb02fc74e866f6