### PR TITLE
Allow configurable decimation and larger images in apriltags_cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,17 @@ target_link_libraries(json_test
     Threads::Threads
     ZLIB::ZLIB)
 
+add_executable(testpic src/testpic.cpp)
+target_link_libraries(testpic
+    apriltag_cuda
+    ${APRILTAG_INSTALL_DIR}/lib/libapriltag.so
+    ${OPENCV_INSTALL_DIR}/lib/libopencv_core.so
+    ${OPENCV_INSTALL_DIR}/lib/libopencv_imgproc.so
+    ${OPENCV_INSTALL_DIR}/lib/libopencv_highgui.so
+    ${OPENCV_INSTALL_DIR}/lib/libopencv_videoio.so
+    ${OPENCV_INSTALL_DIR}/lib/libopencv_imgcodecs.so
+    glog::glog)
+
 # Add a custom target to format all source files
 add_custom_target(format_all
 	COMMAND clang-format -i -style=Google ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp

--- a/src/apriltag_gpu.h
+++ b/src/apriltag_gpu.h
@@ -217,12 +217,12 @@ private:
           .cols = width_,
           .step = width_,
       };
-    } else if (memory.size() == width_ * height_ / 4) {
+    } else if (memory.size() == decimated_width_ * decimated_height_) {
       return GpuImage<T>{
           .data = memory.get(),
-          .rows = height_ / 2,
-          .cols = width_ / 2,
-          .step = width_ / 2,
+          .rows = decimated_height_,
+          .cols = decimated_width_,
+          .step = decimated_width_,
       };
     } else {
       LOG(FATAL) << "Unknown image shape";
@@ -232,6 +232,9 @@ private:
   // Size of the image.
   const size_t width_;
   const size_t height_;
+  const size_t decimation_;
+  const size_t decimated_width_;
+  const size_t decimated_height_;
 
   // Detector parameters.
   apriltag_detector_t *tag_detector_;
@@ -271,7 +274,7 @@ private:
   GpuMemory<uint8_t> color_image_device_;
   // Full size gray scale image.
   GpuMemory<uint8_t> gray_image_device_;
-  // Half resolution, gray, decimated image.
+  // Decimated gray image.
   GpuMemory<uint8_t> decimated_image_device_;
   // Intermediates for thresholding.
   GpuMemory<uint8_t> unfiltered_minmax_image_device_;

--- a/src/points.cu
+++ b/src/points.cu
@@ -9,7 +9,7 @@ std::ostream &operator<<(std::ostream &os, const QuadBoundaryPoint &point) {
   std::ios_base::fmtflags original_flags = os.flags();
 
   os << "key:" << std::hex << std::setw(16) << std::setfill('0') << point.key
-     << " rep01:" << std::setw(10) << point.rep01() << " pt:" << std::setw(6)
+     << " rep01:" << std::setw(10) << point.rep01() << " pt:" << std::setw(10)
      << point.point_bits();
   os.flags(original_flags);
   return os;
@@ -22,12 +22,12 @@ std::ostream &operator<<(std::ostream &os, const IndexPoint &point) {
   std::ios_base::fmtflags original_flags = os.flags();
 
   os << "key:" << std::hex << std::setw(16) << std::setfill('0') << point.key
-     << " i:" << std::setw(3) << point.blob_index() << " t:" << std::setw(7)
-     << point.theta() << " p:" << std::setw(6) << point.point_bits();
+     << " i:" << std::setw(3) << point.blob_index() << " t:" << std::setw(8)
+     << point.theta() << " p:" << std::setw(10) << point.point_bits();
   os.flags(original_flags);
   return os;
 }
 
 static_assert(sizeof(IndexPoint) == 8, "IndexPoint didn't pack right.");
 
-}  // namespace frc971::apriltag
+} // namespace frc971::apriltag

--- a/src/points.h
+++ b/src/points.h
@@ -16,61 +16,61 @@ namespace frc971::apriltag {
 // Class to hold the 2 adjacent blob IDs, a point in decimated image space, the
 // half pixel offset, and the gradient.
 //
-// rep0 and rep1 are the two blob ids, and are each allocated 20 bits.
-// point is the base point and is allocated 10 bits for x and 10 bits for y.
+// rep0 and rep1 are the two blob ids, and are each allocated 15 bits.
+// point is the base point and is allocated 13 bits for x and 13 bits for y.
 // dx and dy are allocated 2 bits, and can only take on set values.
 // black_to_white captures the direction of the gradient in 1 bit.
 //
 // This adds up to 63 bits so we can load this with one big load.
 struct QuadBoundaryPoint {
-  static constexpr size_t kRepEndBit = 24;
+  static constexpr size_t kRepEndBit = 30;
   static constexpr size_t kBitsInKey = 64;
 
   __forceinline__ __host__ __device__ QuadBoundaryPoint() : key(0) {}
 
-  // Sets rep0, the 0th blob id.  This only respects the bottom 20 bits.
+  // Sets rep0, the 0th blob id.  This only respects the bottom 15 bits.
   __forceinline__ __host__ __device__ void set_rep0(uint32_t rep0) {
-    key = (key & 0xfffff00000ffffffull) |
-          (static_cast<uint64_t>(rep0 & 0xfffff) << 24);
+    key = (key & ~(((uint64_t)0x7fff) << 30)) |
+          (static_cast<uint64_t>(rep0 & 0x7fff) << 30);
   }
   // Returns rep0.
   __forceinline__ __host__ __device__ uint32_t rep0() const {
-    return ((key >> 24) & 0xfffff);
+    return ((key >> 30) & 0x7fff);
   }
 
-  // Sets rep1, the 1st blob id.  This only respects the bottom 20 bits.
+  // Sets rep1, the 1st blob id.  This only respects the bottom 15 bits.
   __forceinline__ __host__ __device__ void set_rep1(uint32_t rep1) {
-    key = (key & 0xfffffffffffull) |
-          (static_cast<uint64_t>(rep1 & 0xfffff) << 44);
+    key = (key & ~(((uint64_t)0x7fff) << 45)) |
+          (static_cast<uint64_t>(rep1 & 0x7fff) << 45);
   }
   // Returns rep1.
   __forceinline__ __host__ __device__ uint32_t rep1() const {
-    return ((key >> 44) & 0xfffff);
+    return ((key >> 45) & 0x7fff);
   }
 
-  // Returns both rep0 and rep1 concatenated into a single 40 bit number.
+  // Returns both rep0 and rep1 concatenated into a single 30 bit number.
   __forceinline__ __host__ __device__ uint64_t rep01() const {
-    return ((key >> 24) & 0xffffffffff);
+    return ((key >> 30) & 0x3fffffff);
   }
 
   // Returns all the bits used to hold position and gradient information.
   __forceinline__ __host__ __device__ uint32_t point_bits() const {
-    return key & 0xffffff;
+    return key & 0x3fffffff;
   }
 
-  // Sets the 10 bit x and y.
+  // Sets the 13 bit x and y.
   __forceinline__ __host__ __device__ void set_base_xy(uint32_t x, uint32_t y) {
-    key = (key & 0xffffffffff00000full) |
-          (static_cast<uint64_t>(x & 0x3ff) << 14) |
-          (static_cast<uint64_t>(y & 0x3ff) << 4);
+    key = (key & ~((((uint64_t)0x1fff) << 17) | (((uint64_t)0x1fff) << 4))) |
+          (static_cast<uint64_t>(x & 0x1fff) << 17) |
+          (static_cast<uint64_t>(y & 0x1fff) << 4);
   }
 
-  // Returns the base 10 bit x and y.
+  // Returns the base 13 bit x and y.
   __forceinline__ __host__ __device__ uint32_t base_x() const {
-    return ((key >> 14) & 0x3ff);
+    return ((key >> 17) & 0x1fff);
   }
   __forceinline__ __host__ __device__ uint32_t base_y() const {
-    return ((key >> 4) & 0x3ff);
+    return ((key >> 4) & 0x1fff);
   }
 
   // Sets dxy, the integer representing which of the 4 search directions we
@@ -165,12 +165,12 @@ std::ostream &operator<<(std::ostream &os, const QuadBoundaryPoint &point);
 // Holds a compacted blob index, the angle to the X axis from the center of the
 // blob, and the coordinate of the point.
 //
-// The blob index is 12 bits, the angle is 28 bits, and the point is 24 bits.
+// The blob index is 11 bits, the angle is 23 bits, and the point is 30 bits.
 struct IndexPoint {
   // Max number of blob IDs we can hold.
   static constexpr size_t kMaxBlobs = 2048;
 
-  static constexpr size_t kRepEndBit = 24;
+  static constexpr size_t kRepEndBit = 30;
   static constexpr size_t kBitsInKey = 64;
 
   __forceinline__ __host__ __device__ IndexPoint() : key(0) {}
@@ -180,41 +180,41 @@ struct IndexPoint {
   // by hand.
   __forceinline__ __host__ __device__ IndexPoint(uint32_t blob_index,
                                                  uint32_t point_bits)
-      : key((static_cast<uint64_t>(blob_index & 0xfff) << 52) |
-            (static_cast<uint64_t>(point_bits & 0xffffff))) {}
+      : key((static_cast<uint64_t>(blob_index & 0x7ff) << 53) |
+            (static_cast<uint64_t>(point_bits & 0x3fffffff))) {}
 
-  // Sets and gets the 12 bit blob index.
+  // Sets and gets the 11 bit blob index.
   __forceinline__ __host__ __device__ void set_blob_index(uint32_t blob_index) {
-    key = (key & 0x000fffffffffffffull) |
-          (static_cast<uint64_t>(blob_index & 0xfff) << 52);
+    key = (key & ~(((uint64_t)0x7ff) << 53)) |
+          (static_cast<uint64_t>(blob_index & 0x7ff) << 53);
   }
   __forceinline__ __host__ __device__ uint32_t blob_index() const {
-    return ((key >> 52) & 0xfff);
+    return ((key >> 53) & 0x7ff);
   }
 
-  // Sets and gets the 28 bit angle.
+  // Sets and gets the 23 bit angle.
   __forceinline__ __host__ __device__ void set_theta(uint32_t theta) {
-    key = (key & 0xfff0000000ffffffull) |
-          (static_cast<uint64_t>(theta & 0xfffffff) << 24);
+    key = (key & ~(((uint64_t)0x7fffff) << 30)) |
+          (static_cast<uint64_t>(theta & 0x7fffff) << 30);
   }
   __forceinline__ __host__ __device__ uint32_t theta() const {
-    return ((key >> 24) & 0xfffffff);
+    return ((key >> 30) & 0x7fffff);
   }
 
   // See QuadBoundaryPoint for a description of the rest of these.
-  // Sets the 10 bit x and y.
+  // Sets the 13 bit x and y.
   __forceinline__ __host__ __device__ void set_base_xy(uint32_t x, uint32_t y) {
-    key = (key & 0xffffffffff00000full) |
-          (static_cast<uint64_t>(x & 0x3ff) << 14) |
-          (static_cast<uint64_t>(y & 0x3ff) << 4);
+    key = (key & ~((((uint64_t)0x1fff) << 17) | (((uint64_t)0x1fff) << 4))) |
+          (static_cast<uint64_t>(x & 0x1fff) << 17) |
+          (static_cast<uint64_t>(y & 0x1fff) << 4);
   }
 
   __forceinline__ __host__ __device__ uint32_t base_x() const {
-    return ((key >> 14) & 0x3ff);
+    return ((key >> 17) & 0x1fff);
   }
 
   __forceinline__ __host__ __device__ uint32_t base_y() const {
-    return ((key >> 4) & 0x3ff);
+    return ((key >> 4) & 0x1fff);
   }
 
   __forceinline__ __host__ __device__ void set_dxy(uint64_t dxy) {
@@ -262,7 +262,7 @@ struct IndexPoint {
   }
 
   __forceinline__ __host__ __device__ uint32_t point_bits() const {
-    return key & 0xffffff;
+    return key & 0x3fffffff;
   }
 
   __forceinline__ __host__ __device__ void

--- a/src/testpic.cpp
+++ b/src/testpic.cpp
@@ -1,0 +1,101 @@
+#include <chrono>
+#include <iostream>
+#include <opencv2/opencv.hpp>
+
+#include "apriltag_gpu.h"
+#include "apriltag_utils.h"
+
+extern "C" {
+#include "apriltag.h"
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " image_path\n";
+    return 1;
+  }
+  const char *tag_family = "tag36h11";
+
+  cv::Mat bgr = cv::imread(argv[1], cv::IMREAD_COLOR);
+  if (bgr.empty()) {
+    std::cerr << "Failed to load image: " << argv[1] << "\n";
+    return 1;
+  }
+  int width = bgr.cols;
+  int height = bgr.rows;
+  std::cout << "Image size: " << width << "x" << height << std::endl;
+  if (width % 8 || height % 8) {
+    std::cerr << "Image dimensions must be multiples of 8\n";
+    return 1;
+  }
+
+  cv::Mat gray;
+  cv::cvtColor(bgr, gray, cv::COLOR_BGR2GRAY);
+  image_u8_t im{gray.cols, gray.rows, gray.cols, gray.data};
+
+  apriltag_family_t *tf = nullptr;
+  if (!setup_tag_family(&tf, tag_family)) {
+    std::cerr << "Could not setup tag family\n";
+    return 1;
+  }
+  apriltag_detector_t *td = apriltag_detector_create();
+  apriltag_detector_add_family(td, tf);
+  td->quad_decimate = 1.0;
+  td->quad_sigma = 0.0;
+  td->nthreads = 1;
+  td->debug = false;
+  td->refine_edges = true;
+  td->wp = workerpool_create(1);
+
+  auto cpu_start = std::chrono::steady_clock::now();
+  zarray_t *cpu_detections = apriltag_detector_detect(td, &im);
+  auto cpu_end = std::chrono::steady_clock::now();
+  std::cout << "CPU detections: " << zarray_size(cpu_detections) << " time "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(cpu_end -
+                                                                     cpu_start)
+                   .count()
+            << " ms" << std::endl;
+
+  cv::Mat yuyv;
+  cv::cvtColor(bgr, yuyv, cv::COLOR_BGR2YUV_YUYV);
+
+  frc971::apriltag::CameraMatrix cam{};
+  cam.fx = width;
+  cam.fy = height;
+  cam.cx = width / 2.0;
+  cam.cy = height / 2.0;
+  frc971::apriltag::DistCoeffs dist{};
+
+  frc971::apriltag::GpuDetector gpu(width, height, td, cam, dist);
+
+  auto gpu_start = std::chrono::steady_clock::now();
+  gpu.Detect(yuyv.data);
+  auto gpu_end = std::chrono::steady_clock::now();
+  const zarray_t *gpu_detections = gpu.Detections();
+  std::cout << "GPU detections: " << zarray_size(gpu_detections) << " time "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(gpu_end -
+                                                                     gpu_start)
+                   .count()
+            << " ms" << std::endl;
+
+  bool match = zarray_size(cpu_detections) == zarray_size(gpu_detections);
+  if (match) {
+    for (int i = 0; i < zarray_size(cpu_detections); ++i) {
+      apriltag_detection_t *cd;
+      apriltag_detection_t *gd;
+      zarray_get(cpu_detections, i, &cd);
+      zarray_get(gpu_detections, i, &gd);
+      if (cd->id != gd->id || std::abs(cd->c[0] - gd->c[0]) > 0.5 ||
+          std::abs(cd->c[1] - gd->c[1]) > 0.5) {
+        match = false;
+        break;
+      }
+    }
+  }
+  std::cout << "Results " << (match ? "match" : "do not match") << std::endl;
+
+  apriltag_detections_destroy(cpu_detections);
+  apriltag_detector_destroy(td);
+  teardown_tag_family(&tf, tag_family);
+  return match ? 0 : 2;
+}

--- a/src/threshold.h
+++ b/src/threshold.h
@@ -12,7 +12,7 @@ namespace frc971::apriltag {
 void CudaToGreyscaleAndDecimateHalide(
     const uint8_t *color_image, uint8_t *gray_image, uint8_t *decimated_image,
     uint8_t *unfiltered_minmax_image, uint8_t *minmax_image,
-    uint8_t *thresholded_image, size_t width, size_t height,
+    uint8_t *thresholded_image, size_t width, size_t height, size_t decimation,
     size_t min_white_black_diff, CudaStream *stream);
 
 } // namespace frc971::apriltag


### PR DESCRIPTION
## Summary
- support up to 5120×5120 images by widening point coordinate storage and relaxing pixel count checks
- parameterize decimation factor across GPU detector and thresholding pipeline
- shrink angle scaling to fit within new packed point representation
- add `testpic` utility to time and compare CPU/GPU AprilTag detection on an input image

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6891787671c0832191bb02fc74e866f6