### PR TITLE
Fix CUDA build standards and test file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,27 @@ cmake_minimum_required(VERSION 3.16 FATAL_ERROR)  # Ensure user has a compatible
 
 project(ApriltagCuda LANGUAGES CUDA CXX)  # Set project name and specify the languages used
 
+# Use modern C++ for host code but a slightly older standard for CUDA.
+# The Docker image ships with a CUDA toolkit that does not yet provide
+# full C++20 support. Building the host portion with C++20 is fine, but
+# NVCC 11.x only supports up to C++17. Explicitly set the standards
+# independently so that the build works across environments.
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Look for required packages.
+set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+#Look for required packages.
 find_package(CUDA REQUIRED)
 find_package(glog REQUIRED)
 find_package(GTest REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
 
-#set(GLOG_INSTALL_DIR ${CMAKE_BINARY_DIR}/glog-install)
-#set(GTEST_INSTALL_DIR ${CMAKE_BINARY_DIR}/gtest-install)
+#set(GLOG_INSTALL_DIR ${CMAKE_BINARY_DIR} / glog - install)
+#set(GTEST_INSTALL_DIR ${CMAKE_BINARY_DIR} / gtest - install)
 set(OPENCV_INSTALL_DIR ${CMAKE_BINARY_DIR}/OpenCV-install)
 set(WPILIB_INSTALL_DIR ${CMAKE_BINARY_DIR}/wpilib-install)
 set(CCCL_INSTALL_DIR ${CMAKE_BINARY_DIR}/cccl-install)
@@ -25,7 +33,7 @@ set(SEASOCKS_INSTALL_DIR ${CMAKE_BINARY_DIR}/seasocks-install)
 set(JSON_INSTALL_DIR ${CMAKE_BINARY_DIR}/json-install)
 set(APRILTAG_INSTALL_DIR ${CMAKE_BINARY_DIR}/apriltag-install)
 
-# Determine number of processors for the parallel builds.
+#Determine number of processors for the parallel builds.
 if(NOT DEFINED NUM_PROCESSORS)
     ProcessorCount(NUM_PROCESSORS)
     if(NUM_PROCESSORS EQUAL 0)
@@ -33,7 +41,7 @@ if(NOT DEFINED NUM_PROCESSORS)
     endif()
 endif()
 
-# Add OPENCV package
+#Add OPENCV package
 ExternalProject_Add(
     OpenCV
     PREFIX ${CMAKE_BINARY_DIR}/OpenCV
@@ -47,7 +55,7 @@ ExternalProject_Add(
 set(CMAKE_PREFIX_PATH ${OPENCV_INSTALL_DIR} ${CMAKE_PREFIX_PATH})
 message(STATUS "OPENCV_INSTALL_DIR: ${OPENCV_INSTALL_DIR} CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
 
-# Add wpilib package
+#Add wpilib package
 ExternalProject_Add(
     wpilib
     PREFIX ${CMAKE_BINARY_DIR}/wpilib
@@ -58,7 +66,7 @@ ExternalProject_Add(
     INSTALL_COMMAND make install
 )
 
-# Add CCCL package
+#Add CCCL package
 ExternalProject_Add(
     CCCL 
     PREFIX ${CMAKE_BINARY_DIR}/cccl
@@ -71,7 +79,7 @@ ExternalProject_Add(
 ExternalProject_Get_Property(CCCL SOURCE_DIR)
 set(CCCL_SOURCE_DIR ${SOURCE_DIR})
 
-# Add seasocks package
+#Add seasocks package
 ExternalProject_Add(
     seasocks
     PREFIX ${CMAKE_BINARY_DIR}/seasocks
@@ -92,7 +100,7 @@ ExternalProject_Add(
     INSTALL_COMMAND make install
 )
 
-# Add 971 apriltag package
+#Add 971 apriltag package
 ExternalProject_Add(
     apriltag
     PREFIX ${CMAKE_BINARY_DIR}/apriltag
@@ -106,7 +114,7 @@ ExternalProject_Add(
 add_dependencies(wpilib OpenCV)
 add_dependencies(apriltag OpenCV wpilib CCCL seasocks json)
 
-# Set default build type if not specified
+#Set default build type if not specified
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -117,16 +125,16 @@ if(CMAKE_CUDA_COMPILER)
     if(CMAKE_CUDA_COMPILER MATCHES "nvcc")
         message(STATUS "Using NVCC as CUDA compiler")
         if(CMAKE_BUILD_TYPE MATCHES "Debug")
-            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++20 --expt-relaxed-constexpr -g")
+            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++17 --expt-relaxed-constexpr -g")
         else()
-            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++20 --expt-relaxed-constexpr -Xptxas -O3")
+            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++17 --expt-relaxed-constexpr -Xptxas -O3")
         endif()
     else()
         message(STATUS "Using a different CUDA compiler")
         if(CMAKE_BUILD_TYPE MATCHES "Debug")
-            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++20 -g -gdwarf-4 -O0")
+            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++17 -g -gdwarf-4 -O0")
         else()
-            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++20 -O3")
+            set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std c++17 -O3")
         endif()
     endif()
 else()
@@ -151,7 +159,7 @@ if(ENABLE_MSAN)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${MSAN_FLAGS}")
 endif()
 
-# Gather all source files in the current directory
+#Gather all source files in the current directory
 set(CUDA_LIB_SOURCES 
     src/apriltag_detect.cu 
     src/apriltag_gpu.cu
@@ -169,12 +177,12 @@ set(CUDA_LIB_SOURCES
     src/NetworkTablesUtil.cpp
     src/video_processor.cu)
 
-# Add a library with the above source files
+#Add a library with the above source files
 add_library(apriltag_cuda ${CUDA_LIB_SOURCES})
 
 add_dependencies(apriltag_cuda apriltag)
 
-# Include directories for the compiler
+#Include directories for the compiler
 include_directories( 
     ${APRILTAG_INSTALL_DIR}/include/apriltag
     ${APRILTAG_INSTALL_DIR}/include/apriltag/common/
@@ -187,7 +195,7 @@ include_directories(
     ${SEASOCKS_INSTALL_DIR}/include
     ${JSON_INSTALL_DIR}/include)
 
-# Add executable for OpenCV CUDA demo
+#Add executable for OpenCV CUDA demo
 add_executable(opencv_cuda_demo src/opencv_cuda_demo.cu)
 target_link_libraries(opencv_cuda_demo 
     apriltag_cuda
@@ -199,7 +207,7 @@ target_link_libraries(opencv_cuda_demo
     ${OPENCV_INSTALL_DIR}/lib/libopencv_imgcodecs.so
     glog::glog)
 
-# Add executable for visualize
+#Add executable for visualize
 add_executable(visualize src/visualize.cu)
 target_link_libraries(visualize
     apriltag_cuda
@@ -211,9 +219,7 @@ target_link_libraries(visualize
     ${OPENCV_INSTALL_DIR}/lib/libopencv_imgcodecs.so
     glog::glog)
 
-
-
-# Add the test executable
+#Add the test executable
 add_executable(gpu_detector_test src/gpu_detector_test.cu)
 target_link_libraries(gpu_detector_test
     apriltag_cuda
@@ -278,7 +284,7 @@ target_link_libraries(testpic
     ${OPENCV_INSTALL_DIR}/lib/libopencv_imgcodecs.so
     glog::glog)
 
-# Add a custom target to format all source files
+#Add a custom target to format all source files
 add_custom_target(format_all
 	COMMAND clang-format -i -style=Google ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
     COMMENT "Running clang-format on all source files"

--- a/src/gpu_detector_test.cu
+++ b/src/gpu_detector_test.cu
@@ -1,4 +1,4 @@
-// gpu_detector_test.cpp
+// gpu_detector_test.cu
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -14,7 +14,7 @@ using namespace cv;
 
 // Fixture for the GpuDetector tests
 class GpuDetectorTest : public ::testing::Test {
- protected:
+protected:
   Mat yuyv_img, bgr_img, yuyv_img_notags, bgr_img_notags;
 
   apriltag_family_t *tf = nullptr;


### PR DESCRIPTION
## Summary
- set host C++ to 20 and CUDA to 17 to match NVCC
- compile CUDA with c++17 flags
- mark gpu_detector_test as a .cu test file

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6891c37c2fac8321ab1e6fd60d8911bf