### PR TITLE
Handle CUB radix sort temp storage dynamically

### DIFF
--- a/src/apriltag_gpu.h
+++ b/src/apriltag_gpu.h
@@ -335,7 +335,6 @@ private:
 
   // Temporary storage for each of the steps.
   // TODO(austin): Can we combine these and just use the max?
-  GpuMemory<uint32_t> radix_sort_tmpstorage_device_;
   GpuMemory<uint8_t> temp_storage_compressed_union_marker_pair_device_;
   GpuMemory<uint8_t> temp_storage_bounds_reduce_by_key_device_;
   GpuMemory<uint8_t> temp_storage_dot_product_device_;


### PR DESCRIPTION
## Summary
- allocate temporary storage for `cub::DeviceRadixSort::SortKeys` using CUB's two-step query so buffer size matches each sort invocation
- remove preallocated radix sort buffer from `GpuDetector`

## Testing
- `./test_runner.sh` *(fails: Docker image 'cuda-build' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689206f7ebb083218658e5694c0d5872