### PR TITLE
Handle CUB radix sort temp storage dynamically

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+cmake -S . -B build >/dev/null
+cmake --build build --target testpic -- -j$(nproc) >/dev/null

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -9,4 +9,4 @@ IMAGE_NAME=cuda-build
 docker image inspect "$IMAGE_NAME" > /dev/null 2>&1 || docker build -t "$IMAGE_NAME" .
 
 docker run --rm --memory=16g -v "$(pwd)":/workspace/apriltags_cuda -w /workspace/apriltags_cuda "$IMAGE_NAME" \
-  bash -c "cmake -S . -B build && cmake --build build --target testpic -- -j28"
+  ./build.sh

--- a/src/apriltag_gpu.cu
+++ b/src/apriltag_gpu.cu
@@ -41,16 +41,6 @@ template <typename T> struct True {
   }
 };
 
-// Computes and returns the scratch space needed for DeviceRadixSort::SortKeys
-// of the provided key with the provided number of elements.
-template <typename T> static size_t RadixSortScratchSpace(size_t elements) {
-  size_t temp_storage_bytes = 0;
-  QuadBoundaryPointDecomposer decomposer;
-  cub::DeviceRadixSort::SortKeys(nullptr, temp_storage_bytes, (T *)(nullptr),
-                                 (T *)(nullptr), elements, decomposer);
-  return temp_storage_bytes;
-}
-
 // Computes and returns the scratch space needed for DeviceSelect::If of the
 // provided type Tin, to be written to the provided type Tout, for the provided
 // number of elements.  num_markers is the device pointer used to hold the
@@ -143,8 +133,6 @@ GpuDetector::GpuDetector(size_t width, size_t height,
       peak_extents_device_(kMaxBlobs), camera_matrix_(camera_matrix),
       distortion_coefficients_(distortion_coefficients),
       fit_quads_device_(kMaxBlobs),
-      radix_sort_tmpstorage_device_(RadixSortScratchSpace<QuadBoundaryPoint>(
-          union_marker_pair_device_.size())),
       temp_storage_compressed_union_marker_pair_device_(
           DeviceSelectIfScratchSpace<QuadBoundaryPoint, QuadBoundaryPoint>(
               union_marker_pair_device_.size(),
@@ -820,15 +808,30 @@ void GpuDetector::Detect(const uint8_t *image) {
              union_marker_pair_device_.size());
 
     // Now, sort just the keys to group like points.
-    size_t temp_storage_bytes = radix_sort_tmpstorage_device_.size();
+    VLOG(1) << "SortKeys (union markers): count="
+            << num_compressed_union_marker_pair_host;
+    size_t temp_storage_bytes = 0;
     QuadBoundaryPointDecomposer decomposer;
     CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
-        radix_sort_tmpstorage_device_.get(), temp_storage_bytes,
+        nullptr, temp_storage_bytes, compressed_union_marker_pair_device_.get(),
+        sorted_union_marker_pair_device_.get(),
+        num_compressed_union_marker_pair_host, decomposer,
+        QuadBoundaryPoint::kRepEndBit, QuadBoundaryPoint::kBitsInKey,
+        stream_.get()));
+    VLOG(1) << "  temp storage=" << temp_storage_bytes << " bytes"
+            << " in="
+            << static_cast<const void *>(compressed_union_marker_pair_device_.get())
+            << " out="
+            << static_cast<void *>(sorted_union_marker_pair_device_.get());
+    GpuMemory<uint8_t> radix_sort_tmpstorage_device(temp_storage_bytes);
+    CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
+        radix_sort_tmpstorage_device.get(), temp_storage_bytes,
         compressed_union_marker_pair_device_.get(),
         sorted_union_marker_pair_device_.get(),
         num_compressed_union_marker_pair_host, decomposer,
         QuadBoundaryPoint::kRepEndBit, QuadBoundaryPoint::kBitsInKey,
         stream_.get()));
+    VLOG(1) << "SortKeys (union markers) completed";
 
     MaybeCheckAndSynchronize("cub::DeviceRadixSort::SortKeys");
   }
@@ -952,14 +955,27 @@ void GpuDetector::Detect(const uint8_t *image) {
 
   {
     // Sort based on the angle.
-    size_t temp_storage_bytes = radix_sort_tmpstorage_device_.size();
+    VLOG(1) << "SortKeys (selected blobs): count=" << num_selected_blobs_host;
+    size_t temp_storage_bytes = 0;
     QuadIndexPointDecomposer decomposer;
 
     CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
-        radix_sort_tmpstorage_device_.get(), temp_storage_bytes,
+        nullptr, temp_storage_bytes, selected_blobs_device_.get(),
+        sorted_selected_blobs_device_.get(), num_selected_blobs_host,
+        decomposer, IndexPoint::kRepEndBit, IndexPoint::kBitsInKey,
+        stream_.get()));
+    VLOG(1) << "  temp storage=" << temp_storage_bytes << " bytes"
+            << " in="
+            << static_cast<const void *>(selected_blobs_device_.get())
+            << " out="
+            << static_cast<void *>(sorted_selected_blobs_device_.get());
+    GpuMemory<uint8_t> radix_sort_tmpstorage_device(temp_storage_bytes);
+    CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
+        radix_sort_tmpstorage_device.get(), temp_storage_bytes,
         selected_blobs_device_.get(), sorted_selected_blobs_device_.get(),
         num_selected_blobs_host, decomposer, IndexPoint::kRepEndBit,
         IndexPoint::kBitsInKey, stream_.get()));
+    VLOG(1) << "SortKeys (selected blobs) completed";
 
     MaybeCheckAndSynchronize("cub::DeviceRadixSort::SortKeys");
   }
@@ -1030,14 +1046,25 @@ void GpuDetector::Detect(const uint8_t *image) {
 
   {
     // Sort based on the angle.
-    size_t temp_storage_bytes = radix_sort_tmpstorage_device_.size();
+    VLOG(1) << "SortKeys (peaks): count=" << num_compressed_peaks_host;
+    size_t temp_storage_bytes = 0;
     PeakDecomposer decomposer;
 
     CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
-        radix_sort_tmpstorage_device_.get(), temp_storage_bytes,
+        nullptr, temp_storage_bytes, compressed_peaks_device_.get(),
+        sorted_compressed_peaks_device_.get(), num_compressed_peaks_host,
+        decomposer, 0, PeakDecomposer::kBitsInKey, stream_.get()));
+    VLOG(1) << "  temp storage=" << temp_storage_bytes << " bytes"
+            << " in=" << static_cast<const void *>(compressed_peaks_device_.get())
+            << " out="
+            << static_cast<void *>(sorted_compressed_peaks_device_.get());
+    GpuMemory<uint8_t> radix_sort_tmpstorage_device(temp_storage_bytes);
+    CHECK_CUDA(cub::DeviceRadixSort::SortKeys(
+        radix_sort_tmpstorage_device.get(), temp_storage_bytes,
         compressed_peaks_device_.get(), sorted_compressed_peaks_device_.get(),
         num_compressed_peaks_host, decomposer, 0, PeakDecomposer::kBitsInKey,
         stream_.get()));
+    VLOG(1) << "SortKeys (peaks) completed";
 
     MaybeCheckAndSynchronize("cub::DeviceRadixSort::SortKeys");
   }

--- a/src/apriltag_gpu.h
+++ b/src/apriltag_gpu.h
@@ -335,7 +335,6 @@ private:
 
   // Temporary storage for each of the steps.
   // TODO(austin): Can we combine these and just use the max?
-  GpuMemory<uint32_t> radix_sort_tmpstorage_device_;
   GpuMemory<uint8_t> temp_storage_compressed_union_marker_pair_device_;
   GpuMemory<uint8_t> temp_storage_bounds_reduce_by_key_device_;
   GpuMemory<uint8_t> temp_storage_dot_product_device_;


### PR DESCRIPTION
## Summary
- allocate temporary storage for `cub::DeviceRadixSort::SortKeys` using CUB's two-step query so buffer size matches each sort invocation
- add verbose logging around each radix sort showing key counts, temporary storage size, and device pointers
- provide `build.sh` and update Docker build to suppress compile output except for errors

## Testing
- `./build.sh` *(fails: Failed to find nvcc)*
- `./docker_build.sh` *(fails: docker: command not found)*
- `./test_runner.sh` *(fails: Docker image 'cuda-build' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689206f7ebb083218658e5694c0d5872